### PR TITLE
Add Calendly success page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import OnboardingSuccess from './pages/OnboardingSuccess';
 import NotFound from './pages/NotFound';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import WhatsappRedirect from './pages/WhatsappRedirect';
+import CalendlySuccess from './pages/CalendlySuccess';
 
 const queryClient = new QueryClient();
 
@@ -30,6 +31,7 @@ function App() {
             <Route path="/terms" element={<TermsAndConditions />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
             <Route path="/onboarding-success" element={<OnboardingSuccess />} />
+            <Route path="/calendly-success" element={<CalendlySuccess />} />
             <Route path="/whatsapp" element={<WhatsappRedirect />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/calendly/CalendlySuccessContent.tsx
+++ b/src/components/calendly/CalendlySuccessContent.tsx
@@ -1,0 +1,67 @@
+
+import React from 'react';
+import { Check, MessageSquare, AlertCircle } from 'lucide-react';
+import WhatsappButton from "@/components/WhatsappButton";
+
+const CalendlySuccessContent = () => {
+  return (
+    <div className="text-center space-y-4">
+      <div className="w-16 h-16 bg-green-100 rounded-full mx-auto flex items-center justify-center">
+        <Check className="w-8 h-8 text-green-600" />
+      </div>
+      
+      <h2 className="text-2xl font-bold">¡Cita agendada! 🎉</h2>
+      
+      <div className="space-y-3 text-gray-600">
+        <p>
+          Has agendado correctamente tu cita con nosotros. <span className="font-medium">El siguiente paso es obligatorio:</span>
+        </p>
+        
+        <div className="flex items-center justify-center gap-2 py-1 px-3 rounded-md bg-amber-50 border border-amber-200 text-amber-700 mb-1 mt-1">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          <p className="text-sm font-medium">Contactarnos por WhatsApp para confirmar tu cita</p>
+        </div>
+        
+        <div className="space-y-2 text-left max-w-sm mx-auto">
+          <div className="flex items-start gap-2">
+            <div className="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center text-primary flex-shrink-0 mt-0.5">
+              <Check className="w-3 h-3" />
+            </div>
+            <p className="text-sm">Tu cita ha sido registrada en nuestro sistema</p>
+          </div>
+          
+          <div className="flex items-start gap-2">
+            <div className="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center text-primary flex-shrink-0 mt-0.5">
+              <Check className="w-3 h-3" />
+            </div>
+            <p className="text-sm">Recibirás un correo electrónico con los detalles de la cita</p>
+          </div>
+          
+          <div className="flex items-start gap-2">
+            <div className="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center text-primary flex-shrink-0 mt-0.5">
+              <MessageSquare className="w-3 h-3" />
+            </div>
+            <p className="text-sm">Contáctanos ahora para confirmar tu cita y resolver cualquier duda</p>
+          </div>
+        </div>
+      </div>
+      
+      <div className="mt-6">
+        <WhatsappButton
+          source="calendly_success_page"
+          text="Hola! He agendado una cita en Calendly y me gustaría confirmarla. También tengo algunas preguntas sobre Ruka.ai."
+          className="w-full bg-green-600 hover:bg-green-700 text-white py-3"
+          isSuccessPage={true}
+        >
+          Contactar por WhatsApp
+        </WhatsappButton>
+        
+        <p className="mt-2 text-xs text-gray-500">
+          Toca el botón para contactarnos por WhatsApp y confirmar tu cita
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CalendlySuccessContent;

--- a/src/pages/CalendlySuccess.tsx
+++ b/src/pages/CalendlySuccess.tsx
@@ -1,0 +1,87 @@
+
+import React from 'react';
+import { Helmet } from "react-helmet";
+import { motion } from "framer-motion";
+import { Card, CardContent } from "@/components/ui/card";
+import CalendlySuccessContent from "@/components/calendly/CalendlySuccessContent";
+
+const CalendlySuccess = () => {
+  return (
+    <>
+      <Helmet>
+        <title>¡Cita agendada! | Ruka.ai</title>
+      </Helmet>
+      
+      <main className="min-h-screen flex flex-col md:flex-row relative">
+        <div className="hidden md:flex md:w-1/2 bg-gradient-to-br from-slate-50 to-blue-50 p-8 flex-col overflow-hidden">
+          <div className="max-w-md mx-auto flex-1">
+            <div className="h-full flex flex-col justify-center">
+              <img src="/logo.png" alt="Ruka.ai" className="h-10 mb-6" />
+              <h2 className="text-3xl font-bold mb-4">¡Cita agendada con éxito!</h2>
+              <p className="text-slate-600 mb-6">
+                Has reservado tu cita para conocer más sobre cómo Ruka.ai puede automatizar 
+                y optimizar los procesos de tu negocio.
+              </p>
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M21 8v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V8"></path>
+                      <path d="m9 11 3 3 3-3"></path>
+                      <path d="M12 16V4"></path>
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 className="font-medium text-lg">Automatizamos tus flujos de trabajo</h3>
+                    <p className="text-slate-600">Con IA, automatizamos la clasificación de tus transacciones para que te enfoques en lo importante.</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-blue-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M20 6v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6"></path>
+                      <path d="M16 2H8v4h8V2Z"></path>
+                      <path d="M12 14v-4"></path>
+                      <path d="M9 11h6"></path>
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 className="font-medium text-lg">Todo personalizado a tu negocio</h3>
+                    <p className="text-slate-600">Adaptamos nuestra tecnología a las necesidades específicas de tu negocio.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <div className="flex-1 flex items-center justify-center p-6 md:p-12 bg-white">
+          <div className="w-full max-w-md">
+            <div className="md:hidden mb-8 flex flex-col items-center text-center">
+              <img src="/logo.png" alt="Ruka.ai" className="h-10 mb-4" />
+              <h1 className="text-2xl font-bold mb-2">¡Cita agendada!</h1>
+              <p className="text-slate-600 text-sm mb-6">
+                El siguiente paso es contactarnos por WhatsApp para seguir con el proceso.
+              </p>
+            </div>
+            
+            <motion.div 
+              initial={{ opacity: 0, y: 20 }} 
+              animate={{ opacity: 1, y: 0 }} 
+              transition={{ duration: 0.5 }}
+            >
+              <Card className="border shadow-md">
+                <CardContent className="pt-10 pb-10">
+                  <CalendlySuccessContent />
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default CalendlySuccess;


### PR DESCRIPTION
Create a new page at /calendly-success, mirroring the onboarding success view. This will be used as a redirect target from Calendly, guiding users to contact support via WhatsApp.