### PR TITLE
Fix: Implement Slack TS handling in lead creation

### DIFF
--- a/src/components/restaurant/RegistrationForm.tsx
+++ b/src/components/restaurant/RegistrationForm.tsx
@@ -1,3 +1,4 @@
+
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -9,6 +10,7 @@ import { toast } from "@/components/ui/use-toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { supabase } from "@/integrations/supabase/client";
 import { pushToDataLayer, trackFormSubmission, trackRegistration } from "@/utils/dataLayer";
+
 interface FormData {
   firstName: string;
   lastName: string;
@@ -19,10 +21,12 @@ interface FormData {
   codigoPromocional: string;
   acceptTerms: boolean;
 }
+
 interface RegistrationFormProps {
   highlightForm: boolean;
   timeLeft: string;
 }
+
 export default function RegistrationForm({
   highlightForm,
   timeLeft
@@ -39,11 +43,14 @@ export default function RegistrationForm({
     acceptTerms: false
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
     pushToDataLayer('registration_form_submit_attempt', {
       has_terms_accepted: formData.acceptTerms
     });
+
     if (!formData.acceptTerms) {
       pushToDataLayer('registration_validation_error', {
         error_type: 'terms_not_accepted'
@@ -55,9 +62,11 @@ export default function RegistrationForm({
       });
       return;
     }
+
     try {
       setIsSubmitting(true);
       const whatsappNumber = formData.whatsapp ? `+56${formData.whatsapp.replace(/^\+56/, '')}` : '';
+
       trackFormSubmission('restaurant_registration', {
         email_domain: formData.email.split('@')[1],
         has_whatsapp: !!formData.whatsapp,
@@ -66,34 +75,12 @@ export default function RegistrationForm({
         has_promo_code: !!formData.codigoPromocional
       }, true);
 
-      // First create the lead record
-      const {
-        data: leadData,
-        error: leadError
-      } = await supabase.from('leads').insert([{
-        company_name: formData.nombreRestaurante,
-        name: `${formData.firstName} ${formData.lastName}`,
-        first_name: formData.firstName,
-        last_name: formData.lastName,
-        email: formData.email,
-        ccity: formData.ciudad,
-        whatsapp: whatsappNumber,
-        codigo_promocional: formData.codigoPromocional || null
-      }]).select().single();
-      if (leadError) {
-        throw leadError;
-      }
-
-      // Get the ID of the inserted lead
-      const leadId = leadData.id;
-      pushToDataLayer('lead_created', {
-        lead_id: leadId,
-        company_name: formData.nombreRestaurante
-      });
-
-      // Send notification to Slack about the new lead (only for initial registration)
+      // First, try to send Slack notification and get the timestamp
+      let slackTimestamp: string | null = null;
+      
       try {
-        const slackResponse = await supabase.functions.invoke('notify-slack', {
+        // Send Slack notification
+        const slackPromise = supabase.functions.invoke('notify-slack', {
           body: {
             lead: {
               company_name: formData.nombreRestaurante,
@@ -102,60 +89,95 @@ export default function RegistrationForm({
               ccity: formData.ciudad,
               whatsapp: whatsappNumber
             },
-            isOnboarding: false // Esta es una notificación inicial, no una actualización de onboarding
+            isOnboarding: false
           }
         });
-        if (slackResponse.error) {
-          // Don't throw error here, just log warning
-        } else if (slackResponse.data?.ts) {
-          // Store the Slack message timestamp for future thread replies
-          const slackTs = slackResponse.data.ts;
-          pushToDataLayer('slack_notification_sent', {
-            lead_id: leadId
-          });
 
-          // Use the more reliable Edge Function to update the lead record
-          const updateResponse = await supabase.functions.invoke('update-lead', {
-            body: {
-              leadId: leadId,
-              updateData: {
-                slack_message_ts: slackTs
-              }
-            }
-          });
-          if (updateResponse.error) {
-            // Error handling
-          } else {
-            // Verification step - Check if the timestamp was actually stored
-            const {
-              data: verifyData,
-              error: verifyError
-            } = await supabase.from('leads').select('slack_message_ts').eq('id', leadId).single();
-            if (verifyError) {
-              // Error handling
-            } else {
-              if (verifyData.slack_message_ts !== slackTs) {
-                // Try one more direct update as fallback
-                const {
-                  error: directUpdateError
-                } = await supabase.from('leads').update({
-                  slack_message_ts: slackTs
-                }).eq('id', leadId);
-                if (directUpdateError) {
-                  // Error handling
-                } else {
-                  // Final verification
-                  const {
-                    data: finalVerifyData
-                  } = await supabase.from('leads').select('slack_message_ts').eq('id', leadId).single();
-                }
-              }
-            }
-          }
+        // Create a timeout promise (2 seconds)
+        const timeoutPromise = new Promise<null>((resolve) => {
+          setTimeout(() => resolve(null), 2000);
+        });
+
+        // Race between Slack response and timeout
+        const slackResult = await Promise.race([slackPromise, timeoutPromise]);
+        
+        // If Slack responded in time and has a timestamp, store it
+        if (slackResult && !slackResult.error && slackResult.data?.ts) {
+          slackTimestamp = slackResult.data.ts;
+          console.log('Slack timestamp received in time:', slackTimestamp);
+        } else {
+          console.log('Slack notification timed out or failed, proceeding without timestamp');
         }
       } catch (slackError) {
-        // Don't throw error here, just log warning
+        console.log('Slack notification error, proceeding without timestamp:', slackError);
       }
+
+      // Create the lead data object
+      const leadDataToInsert: any = {
+        company_name: formData.nombreRestaurante,
+        name: `${formData.firstName} ${formData.lastName}`,
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+        email: formData.email,
+        ccity: formData.ciudad,
+        whatsapp: whatsappNumber,
+        codigo_promocional: formData.codigoPromocional || null
+      };
+
+      // Add slack_message_ts if we got it in time
+      if (slackTimestamp) {
+        leadDataToInsert.slack_message_ts = slackTimestamp;
+      }
+
+      // Insert the lead record with or without the timestamp
+      const {
+        data: leadData,
+        error: leadError
+      } = await supabase.from('leads').insert([leadDataToInsert]).select().single();
+
+      if (leadError) {
+        throw leadError;
+      }
+
+      const leadId = leadData.id;
+      pushToDataLayer('lead_created', {
+        lead_id: leadId,
+        company_name: formData.nombreRestaurante
+      });
+
+      // If we didn't get the timestamp in time, handle the update asynchronously
+      if (!slackTimestamp) {
+        // This runs in background without blocking the user flow
+        supabase.functions.invoke('notify-slack', {
+          body: {
+            lead: {
+              company_name: formData.nombreRestaurante,
+              name: `${formData.firstName} ${formData.lastName}`,
+              email: formData.email,
+              ccity: formData.ciudad,
+              whatsapp: whatsappNumber
+            },
+            isOnboarding: false
+          }
+        }).then((slackResponse) => {
+          if (!slackResponse.error && slackResponse.data?.ts) {
+            // Update the lead with the timestamp when it arrives
+            supabase.functions.invoke('update-lead', {
+              body: {
+                leadId: leadId,
+                updateData: {
+                  slack_message_ts: slackResponse.data.ts
+                }
+              }
+            }).catch((updateError) => {
+              console.log('Error updating lead with late timestamp:', updateError);
+            });
+          }
+        }).catch((slackError) => {
+          console.log('Background Slack notification failed:', slackError);
+        });
+      }
+
       trackRegistration({
         lead_id: leadId,
         restaurant_name: formData.nombreRestaurante
@@ -181,11 +203,9 @@ export default function RegistrationForm({
       setIsSubmitting(false);
     }
   };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const {
-      name,
-      value
-    } = e.target;
+    const { name, value } = e.target;
     if (name === 'whatsapp') {
       const cleanedValue = value.replace(/^\+56/, '').replace(/[^0-9]/g, '');
       setFormData(prev => ({
@@ -199,13 +219,15 @@ export default function RegistrationForm({
       [name]: value
     }));
   };
-  return <motion.div initial={{
-    opacity: 0,
-    scale: 0.95
-  }} animate={{
-    opacity: 1,
-    scale: 1
-  }} className={`bg-white rounded-xl shadow-xl border p-6 sm:p-8 space-y-6 sm:space-y-8 transition-all duration-300 w-full ${highlightForm ? 'ring-4 ring-primary shadow-2xl scale-105' : ''}`}>
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      className={`bg-white rounded-xl shadow-xl border p-6 sm:p-8 space-y-6 sm:space-y-8 transition-all duration-300 w-full ${
+        highlightForm ? 'ring-4 ring-primary shadow-2xl scale-105' : ''
+      }`}
+    >
       <div className="space-y-4">
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-semibold">Prueba Ruka por 30 días</h2>
@@ -213,7 +235,7 @@ export default function RegistrationForm({
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="cursor-help">
-                  
+                  <HelpCircle className="w-4 h-4 text-muted-foreground" />
                 </div>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-[200px] p-3">
@@ -222,21 +244,59 @@ export default function RegistrationForm({
             </Tooltip>
           </TooltipProvider>
         </div>
-        <p className="text-lg text-muted-foreground font-medium">Si no te gusta o no le ves valor, emitimos una NC por el 100%. Sin preguntas, sin letra chica.</p>
+        <p className="text-lg text-muted-foreground font-medium">
+          Si no te gusta o no le ves valor, emitimos una NC por el 100%. Sin preguntas, sin letra chica.
+        </p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <Input id="registration-first-name" name="firstName" placeholder="Nombre" value={formData.firstName} onChange={handleChange} required className="h-12" disabled={isSubmitting} />
-          <Input id="registration-last-name" name="lastName" placeholder="Apellido" value={formData.lastName} onChange={handleChange} required className="h-12" disabled={isSubmitting} />
+          <Input
+            id="registration-first-name"
+            name="firstName"
+            placeholder="Nombre"
+            value={formData.firstName}
+            onChange={handleChange}
+            required
+            className="h-12"
+            disabled={isSubmitting}
+          />
+          <Input
+            id="registration-last-name"
+            name="lastName"
+            placeholder="Apellido"
+            value={formData.lastName}
+            onChange={handleChange}
+            required
+            className="h-12"
+            disabled={isSubmitting}
+          />
         </div>
-        <Input id="registration-email" name="email" type="email" placeholder="Email" value={formData.email} onChange={handleChange} required className="h-12" disabled={isSubmitting} />
+        <Input
+          id="registration-email"
+          name="email"
+          type="email"
+          placeholder="Email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+          className="h-12"
+          disabled={isSubmitting}
+        />
         <div className="relative">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="relative">
-                  <Input id="registration-whatsapp" name="whatsapp" placeholder="WhatsApp (opcional)" value={formData.whatsapp} onChange={handleChange} className="h-12 pl-16 pr-10" disabled={isSubmitting} />
+                  <Input
+                    id="registration-whatsapp"
+                    name="whatsapp"
+                    placeholder="WhatsApp (opcional)"
+                    value={formData.whatsapp}
+                    onChange={handleChange}
+                    className="h-12 pl-16 pr-10"
+                    disabled={isSubmitting}
+                  />
                   <div className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
                     +56
                   </div>
@@ -249,15 +309,41 @@ export default function RegistrationForm({
             </Tooltip>
           </TooltipProvider>
         </div>
-        <Input id="registration-city" name="ciudad" placeholder="Ciudad" value={formData.ciudad} onChange={handleChange} required className="h-12" disabled={isSubmitting} />
-        <Input id="registration-restaurant-name" name="nombreRestaurante" placeholder="Nombre de tu Empresa" value={formData.nombreRestaurante} onChange={handleChange} required className="h-12" disabled={isSubmitting} />
+        <Input
+          id="registration-city"
+          name="ciudad"
+          placeholder="Ciudad"
+          value={formData.ciudad}
+          onChange={handleChange}
+          required
+          className="h-12"
+          disabled={isSubmitting}
+        />
+        <Input
+          id="registration-restaurant-name"
+          name="nombreRestaurante"
+          placeholder="Nombre de tu Empresa"
+          value={formData.nombreRestaurante}
+          onChange={handleChange}
+          required
+          className="h-12"
+          disabled={isSubmitting}
+        />
         
         <div className="relative">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="relative">
-                  <Input id="registration-promo-code" name="codigoPromocional" placeholder="Código promocional (opcional)" value={formData.codigoPromocional} onChange={handleChange} className="h-12 pl-12 pr-4" disabled={isSubmitting} />
+                  <Input
+                    id="registration-promo-code"
+                    name="codigoPromocional"
+                    placeholder="Código promocional (opcional)"
+                    value={formData.codigoPromocional}
+                    onChange={handleChange}
+                    className="h-12 pl-12 pr-4"
+                    disabled={isSubmitting}
+                  />
                   <Tag className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
                 </div>
               </TooltipTrigger>
@@ -269,25 +355,53 @@ export default function RegistrationForm({
         </div>
         
         <div className="flex items-start space-x-2">
-          <Checkbox id="registration-terms" checked={formData.acceptTerms} onCheckedChange={checked => setFormData(prev => ({
-          ...prev,
-          acceptTerms: checked as boolean
-        }))} disabled={isSubmitting} />
+          <Checkbox
+            id="registration-terms"
+            checked={formData.acceptTerms}
+            onCheckedChange={(checked) =>
+              setFormData(prev => ({
+                ...prev,
+                acceptTerms: checked as boolean
+              }))
+            }
+            disabled={isSubmitting}
+          />
           <label htmlFor="registration-terms" className="text-sm text-muted-foreground leading-relaxed">
             Acepto los{" "}
-            <Link to="/terms" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+            <Link
+              to="/terms"
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               términos y condiciones
             </Link>{" "}
             y las{" "}
-            <Link to="/privacy" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+            <Link
+              to="/privacy"
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               políticas de privacidad
             </Link>
           </label>
         </div>
         
         <div className="space-y-4">
-          <Button id="registration-submit" type="submit" className="w-full gap-2 h-12 text-lg" disabled={!formData.acceptTerms || isSubmitting}>
-            {isSubmitting ? <>Procesando...</> : <>Comenzar Ahora <ArrowRight className="w-5 h-5" /></>}
+          <Button
+            id="registration-submit"
+            type="submit"
+            className="w-full gap-2 h-12 text-lg"
+            disabled={!formData.acceptTerms || isSubmitting}
+          >
+            {isSubmitting ? (
+              <>Procesando...</>
+            ) : (
+              <>
+                Comenzar Ahora <ArrowRight className="w-5 h-5" />
+              </>
+            )}
           </Button>
           
           <div className="flex items-center justify-center gap-4 flex-wrap">
@@ -306,5 +420,6 @@ export default function RegistrationForm({
           </div>
         </div>
       </form>
-    </motion.div>;
+    </motion.div>
+  );
 }


### PR DESCRIPTION
Implement the plan to handle the `slack_message_ts` in `src/components/restaurant/RegistrationForm.tsx`. The lead should be created with the `ts` if it arrives within 2 seconds, otherwise, create the lead without the `ts` and update it later.